### PR TITLE
Force python version in testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27, flake8
 
 [testenv]
+basepython=python2.7
 sitepackages = true
 deps =
     coverage


### PR DESCRIPTION
This change is needed for platforms when tox is python3 script (like
Ubuntu 15.04)
